### PR TITLE
fix: support unset valuepair

### DIFF
--- a/specs/statements/unset-statement/__snapshots__/index.spec.ts.snap
+++ b/specs/statements/unset-statement/__snapshots__/index.spec.ts.snap
@@ -77,6 +77,155 @@ Array [
 ]
 `;
 
+exports[`unset-statement valuepair ast: ast 1`] = `
+Node {
+  "id": Node {
+    "base": Node {
+      "base": Node {
+        "base": Node {
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": Object {
+              "column": 7,
+              "line": 1,
+              "offset": 6,
+            },
+          },
+          "name": "req",
+          "type": "Identifier",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 1,
+            "offset": 13,
+          },
+          "start": Object {
+            "column": 7,
+            "line": 1,
+            "offset": 6,
+          },
+        },
+        "member": Node {
+          "loc": Object {
+            "end": Object {
+              "column": 14,
+              "line": 1,
+              "offset": 13,
+            },
+            "start": Object {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "name": "http",
+          "type": "Identifier",
+        },
+        "type": "Member",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+          "offset": 20,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+          "offset": 6,
+        },
+      },
+      "member": Node {
+        "loc": Object {
+          "end": Object {
+            "column": 21,
+            "line": 1,
+            "offset": 20,
+          },
+          "start": Object {
+            "column": 16,
+            "line": 1,
+            "offset": 15,
+          },
+        },
+        "name": "Cookie",
+        "type": "Identifier",
+      },
+      "type": "Member",
+    },
+    "loc": Object {
+      "end": Object {
+        "column": 32,
+        "line": 1,
+        "offset": 31,
+      },
+      "start": Object {
+        "column": 7,
+        "line": 1,
+        "offset": 6,
+      },
+    },
+    "name": Node {
+      "loc": Object {
+        "end": Object {
+          "column": 32,
+          "line": 1,
+          "offset": 31,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "name": "session_id",
+      "type": "Identifier",
+    },
+    "type": "ValuePair",
+  },
+  "loc": Object {
+    "end": Object {
+      "column": 33,
+      "line": 1,
+      "offset": 32,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "UnsetStatement",
+}
+`;
+
+exports[`unset-statement valuepair format: format long 1`] = `unset req.http.Cookie:session_id;`;
+
+exports[`unset-statement valuepair format: format short 1`] = `
+unset req
+  .http
+  .Cookie:session_id;
+`;
+
+exports[`unset-statement valuepair token 1`] = `
+Array [
+  unset,
+  req,
+  .,
+  http,
+  .,
+  Cookie,
+  :,
+  session_id,
+  ;,
+]
+`;
+
 exports[`unset-statement variable ast: ast 1`] = `
 Node {
   "id": Node {

--- a/specs/statements/unset-statement/valuepair.vcl
+++ b/specs/statements/unset-statement/valuepair.vcl
@@ -1,0 +1,1 @@
+unset req.http.Cookie:session_id;

--- a/src/nodes/builders.gen.ts
+++ b/src/nodes/builders.gen.ts
@@ -380,7 +380,7 @@ export function buildSetStatement(
 }
 
 export function buildUnsetStatement(
-  id: d.Identifier | d.Member,
+  id: d.Identifier | d.Member | d.ValuePair,
   loc?: Location
 ): NodeWithLoc<d.UnsetStatement> {
   const node = Object.create(BaseNode.prototype) as NodeWithLoc<

--- a/src/nodes/defs.ts
+++ b/src/nodes/defs.ts
@@ -182,7 +182,7 @@ export interface SetStatement extends BaseNode {
 
 export interface UnsetStatement extends BaseNode {
   type: 'UnsetStatement'
-  id: Identifier | Member
+  id: Identifier | Member | ValuePair
 }
 
 export type ReturnActionName =

--- a/src/parser/statement/index.ts
+++ b/src/parser/statement/index.ts
@@ -39,7 +39,7 @@ export const parseStmt = (p: Parser, token: Token = p.read()): d.Statement => {
   }
 
   if (token.value === 'unset') {
-    const id = p.validateNode(parseExpr(p), 'Identifier', 'Member')
+    const id = p.validateNode(parseExpr(p), 'Identifier', 'Member', 'ValuePair')
 
     ensureSemi(p)
 


### PR DESCRIPTION
I'd like to support `unset Cookie:foo` which is common in Fastly.

Thanks!