### PR TITLE
Emit typescript declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "npm run -s build > /dev/null && node dist/cli",
-    "build": "babel src -d dist -x .ts,.js --delete-dir-on-start",
+    "build": "babel src -d dist -x .ts,.js --delete-dir-on-start && tsc -p tsconfig.build.json",
     "inspect": "yarn lint && yarn typecheck && yarn test",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
AST parsers and formatters (and so on) in this tool are very useful to develop relevant tools to VCL.
Therefore, could you include TypeScript declaration files (.d.ts) in build artifacts? Thanks.